### PR TITLE
Shannon Woods image name mismatch.

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -883,7 +883,7 @@ Vladimir has been working on Firefox and open web standards for over ten years. 
 <!-- ====================================================================== -->
 
 <tr id="ShannonWoods">
-<td valign="top"><img src="contributors/ShannonWoods.jpg" width="128" alt="" /></td>
+<td valign="top"><img src="contributors/shannonwoods.jpg" width="128" alt="" /></td>
 <td>
 <p>
 <span style='font-weight:bold;'>Shannon Woods</span><br />


### PR DESCRIPTION
Noticed that Shannon Woods' image wasn't showing up on the live version. I'm guessing that GitHub uses Linux servers which would be case-sensitive (explaining why the problem wouldn't have been caught on Mac/Windows).
